### PR TITLE
fix bug for data in *_IntegrationPoints

### DIFF
--- a/cpp/odb2vtk.cpp
+++ b/cpp/odb2vtk.cpp
@@ -391,7 +391,7 @@ void odb2vtk::WriteSortedCellData(const odb_SequenceFieldBulkData &blkDataBlock,
     int numIP = numValues / nElems;
     float *data = blk.data();
     for (int j = 0; j < nElems; j++) {
-      int cellLabelAbq = blk.elementLabels()[j];
+      int cellLabelAbq = blk.elementLabels()[j * numIP];
       INT64 cellLabelVtk = m_cellsMap[instanceName][cellLabelAbq];
       for (int ip = 0; ip < numIP; ip++) {
         for (int comp = 0; comp < numComp; comp++) {


### PR DESCRIPTION
When writing *_IntegrationPoints data, the data in blk.elementLabels() is not a continuous label, and the number of repetitions is equal to the number of integration points. For example, for 8 integration points, the elementLabels is: 1111 1111 2222 2222 ....